### PR TITLE
Add table name to Features model

### DIFF
--- a/src/resources/feature/models/index.js
+++ b/src/resources/feature/models/index.js
@@ -34,6 +34,7 @@ const options = {
     { fields: ['account_id', 'owner_id'] },
     { fields: ['account_id', 'owner_id', 'key'] },
   ],
+  tableName: 'Features',
 }
 
 const create = (database) => database.define('Feature', attributes, options)


### PR DESCRIPTION
# Description

In order to make the project work as expected we need to actively add a tableName property to the options object when defining a new model. That's needed due the way sequelize works, always trying to lowercase table names, which is not what we're planning to do.